### PR TITLE
add static code analysis, add names to devops stages

### DIFF
--- a/.github/workflows/AutoBuild.yaml
+++ b/.github/workflows/AutoBuild.yaml
@@ -9,6 +9,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Build application
     
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-python
     steps:
@@ -23,7 +24,7 @@ jobs:
       - name: test python is functionnal
         run: python -c "import sys; print(sys.version)"
       
-      - name: Pepare dependencies python, cmake
+      - name: Prepare dependencies python, cmake
         run: |
           python -m pip install --upgrade pip
           sudo apt install cmake -y
@@ -39,8 +40,47 @@ jobs:
       - name: Build the project
         run: ./scripts-ci/build.sh ${{env.path}}
 
+      # Upload build artifact for static analysis
+      - name: Upload the Build final folder
+        uses: actions/upload-artifact@v2
+        with:
+          name: Build
+          path: ${{ env.path }}/build-fprime-automatic-native
+
+  static_code_analysis:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Static code Analysis
+    steps:
+
+      - name: download buld folder
+        uses: actions/download-artifact@v2
+        with:
+          name: Build
+
+      - name : prepare cppcheck
+        run: |
+          sudo apt install cppcheck -y
+          sudo apt install python-pygments -y
+
+      - name: Compute cppcheck code analysis
+        run: cppcheck --xml --force . 2>./cppcheck.xml
+
+      - name: Transform  XML into HTML
+        run: |
+          mkdir check-html/
+          cppcheck-htmlreport --file=cppcheck.xml --report-dir=./check-html/ --source-dir=. --title=CHESS-mission
+
+      - name: upload HTML files 
+        uses: actions/upload-artifact@v2
+        with:
+          name: cppCheck coverage report
+          path: ./check-html
+
   app_unit_test:
     runs-on: ubuntu-latest
+    name: Local unit tests
+
     steps:
       # checkout the repository
       - uses: actions/checkout@v2
@@ -71,6 +111,7 @@ jobs:
 
   global_unit_test:
     runs-on: ubuntu-latest
+    name: Global unit tests
     steps:
       # checkout the repository
       - uses: actions/checkout@v2


### PR DESCRIPTION
## CHESS 05_FS Pull Request
|**Field**|**Value**|
|:---|:---|
|**_Base Branch_**| Dev |
|**_Short Description_**| Enhance Devops by adding cppcheck as static code analysis |
|**_Affected Component_**| Entire App |
|**_Affected Architectures(s)_**| Entire App  |
|**_Related Issue(s)_**| Devops - testing the C/C++ code  |
|**_Has Unit Tests (y/n)_**| y |
|**_Build Checked (y/n)_**| y |
|**_Unit Tests Run (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description
This adds a step in the "autobuild" action : a static code analysis performed by cppcheck

## Rationale
This change takes place in the test suit composed of
* **Static code analysis**
* Build/Compilation
* Unit test
* Integration test

## Testing Recommendations
Download the "coverage report" artifact from the action when it runs, and check it if there is an error (open index.html)

## Future Work
None