### PR TITLE
add archive as build-artifacts to start them if necessary

### DIFF
--- a/.github/workflows/Delivery.yaml
+++ b/.github/workflows/Delivery.yaml
@@ -82,4 +82,7 @@ jobs:
 
       #put the build-artifacts folder as archive
       - name: Put version in archive
-        run: cp -r build-artifacts ${{ env.delivery-path }}/archives/$(date +"%d_%m_%Y_%H:%M:%S")
+        run: |
+          date_now=$(date +"%d_%m_%Y_%H:%M:%S")
+          mkdir ${{ env.delivery-path }}/archives/$date_now
+          cp -r build-artifacts ${{ env.delivery-path }}/archives/$date_now/build-artifacts


### PR DESCRIPTION
* little archive hotfix to start the archive folder easily if necessary from the Pi